### PR TITLE
Updated textbox

### DIFF
--- a/FGUI/controls/container.cc
+++ b/FGUI/controls/container.cc
@@ -408,6 +408,10 @@ void fgui::container::update() {
 		//else
 		//	handler::set_cursor(fgui::cursor_type::ARROW);
 	}
+	else if (element->get_flag(fgui::detail::element_flags::CLICKABLE) && !fgui::input_system::mouse_in_area(control_area) && fgui::input_system::key_press(fgui::external::MOUSE_LEFT) && !focused_element_clicked)
+	{
+		element->handle_input();
+	}
 
 	// iterate over the rest of the elements
 	for (std::shared_ptr<fgui::element> element : m_elements) {

--- a/FGUI/controls/listbox.cc
+++ b/FGUI/controls/listbox.cc
@@ -15,8 +15,8 @@ fgui::listbox::listbox() {
 	fgui::listbox::m_slider_top = 0;
 	fgui::listbox::m_item_height = 20;
 	fgui::listbox::m_font = fgui::element::m_font;
-	fgui::listbox::m_type =  static_cast<int>(fgui::detail::element_type::LISTBOX);
-	fgui::element::m_flags =  static_cast<int>(fgui::detail::element_flags::DRAWABLE) |  static_cast<int>(fgui::detail::element_flags::CLICKABLE) |  static_cast<int>(fgui::detail::element_flags::SAVABLE);
+	fgui::listbox::m_type = static_cast<int>(fgui::detail::element_type::LISTBOX);
+	fgui::element::m_flags = static_cast<int>(fgui::detail::element_flags::DRAWABLE) | static_cast<int>(fgui::detail::element_flags::CLICKABLE) | static_cast<int>(fgui::detail::element_flags::SAVABLE);
 }
 
 //---------------------------------------------------------
@@ -32,7 +32,7 @@ void fgui::listbox::draw() {
 	fgui::rect area = { a.x, a.y, m_width, m_height };
 
 	// get the number of displayed items
-	static int item_displayed = 0;
+	int item_displayed = 0;
 
 	// calculate the quantity of entries that will be drawned on the listbox
 	static int calculated_items = m_height / m_item_height;
@@ -98,7 +98,7 @@ void fgui::listbox::draw() {
 		calculated_size = 1.f;
 
 	calculated_size *= m_height;
-	
+
 	// scrollbar area
 	fgui::rect scrollbar_area = { (area.left + 2) + (area.right - 15), area.top + 2, 15 - 4, area.bottom - 4 };
 
@@ -114,14 +114,14 @@ void fgui::listbox::draw() {
 
 	// dots
 	if (m_dragging) {
-		
+
 		fgui::render.rect(scrollbar_area.left + 5, (scrollbar_area.top + calculated_position) + 2 + (calculated_size / 2) - 1, 1, 1, fgui::color(style.listbox.at(3)));
 		fgui::render.rect(scrollbar_area.left + 5, (scrollbar_area.top + calculated_position) + 2 + (calculated_size / 2) - 3, 1, 1, fgui::color(style.listbox.at(3)));
 		fgui::render.rect(scrollbar_area.left + 5, (scrollbar_area.top + calculated_position) + 2 + (calculated_size / 2) - 5, 1, 1, fgui::color(style.listbox.at(3)));
 	}
 
 	else if (!m_dragging) {
-		
+
 		fgui::render.rect(scrollbar_area.left + 5, (scrollbar_area.top + calculated_position) + 2 + (calculated_size / 2) - 1, 1, 1, fgui::color(style.text.at(0)));
 		fgui::render.rect(scrollbar_area.left + 5, (scrollbar_area.top + calculated_position) + 2 + (calculated_size / 2) - 3, 1, 1, fgui::color(style.text.at(0)));
 		fgui::render.rect(scrollbar_area.left + 5, (scrollbar_area.top + calculated_position) + 2 + (calculated_size / 2) - 5, 1, 1, fgui::color(style.text.at(0)));
@@ -143,13 +143,13 @@ void fgui::listbox::handle_input() {
 		fgui::rect scrollbar_area = { (area.left + 2) + (area.right - 15), area.top + 2, 15 - 4, area.bottom - 4 };
 
 		if (fgui::input_system::mouse_in_area(scrollbar_area)) {
-					
-			if (fgui::input_system::key_held(fgui::external::MOUSE_LEFT)) 
+
+			if (fgui::input_system::key_held(fgui::external::MOUSE_LEFT))
 				m_dragging = true;
 		}
 
 		// get the number of displayed items
-		static int item_displayed = 0;
+		int item_displayed = 0;
 
 		// calculate the amount of items to be drawned
 		static int calculated_items = m_height / m_item_height;
@@ -246,7 +246,7 @@ void fgui::listbox::save(nlohmann::json& json_module) {
 
 //---------------------------------------------------------
 void fgui::listbox::load(const std::string_view file_name) {
-	
+
 	nlohmann::json json_module;
 
 	// open the file

--- a/FGUI/controls/textbox.cc
+++ b/FGUI/controls/textbox.cc
@@ -42,7 +42,7 @@ void fgui::textbox::draw() {
 
 	// textbox body
 	fgui::render.outline(area.left, area.top, area.right, area.bottom, fgui::color(style.textbox.at(0)));
-	
+
 	if (fgui::input_system::mouse_in_area(area) || m_is_getting_key)
 		fgui::render.outline(area.left + 2, area.top + 2, area.right - 4, area.bottom - 4, fgui::color(style.textbox.at(3)));
 	else
@@ -59,27 +59,63 @@ void fgui::textbox::draw() {
 	// typed text size
 	fgui::dimension typed_text_size = fgui::render.get_text_size(fgui::textbox::get_font(), m_text);
 
+	//The text won't fit in the box
+	int number_errased = 0;
+	std::string to_write = m_text;
+
+	while (typed_text_size.width + 7 > m_width)
+	{
+		if (m_text_input_pos >= number_errased && m_text_input_pos > 1)
+		{
+			to_write.erase(to_write.begin());
+			number_errased++;
+		}
+		else
+		{
+			to_write.pop_back();
+		}
+		typed_text_size = fgui::render.get_text_size(fgui::textbox::get_font(), to_write);
+
+	}
+
 	// draw custom text
 	if (m_text_flag & static_cast<int>(fgui::text_flags::SECRET))
-		fgui::render.text(area.left + 5, area.top + (area.bottom / 2) - (typed_text_size.height / 2) - 1, fgui::color(style.text.at(0)), fgui::textbox::get_font(), std::string(m_text.length(), '*'));
-	
-	else if (m_text_flag & static_cast<int>(fgui::text_flags::UPPERCASE)) {
-		
+	{
+		fgui::render.text(area.left + 5, area.top + (area.bottom / 2) - (typed_text_size.height / 2) - 1, fgui::color(style.text.at(0)), fgui::textbox::get_font(), std::string(to_write.length(), '*'));
+	}
+
+	else if (m_text_flag & static_cast<int>(fgui::text_flags::UPPERCASE))
+	{
+
 		// transform the text into uppercase
-		std::string upper_case_display = m_text;
-		std::transform(upper_case_display.begin(), upper_case_display.end(),upper_case_display.begin(), ::toupper);
+		std::string upper_case_display = to_write;
+		std::transform(upper_case_display.begin(), upper_case_display.end(), upper_case_display.begin(), ::toupper);
 
 		fgui::render.text(area.left + 5, area.top + (area.bottom / 2) - (typed_text_size.height / 2) - 1, fgui::color(style.text.at(0)), fgui::textbox::get_font(), upper_case_display);
 	}
 	else
-		fgui::render.text(area.left + 5, area.top + (area.bottom / 2) - (typed_text_size.height / 2) - 1, fgui::color(style.text.at(0)), fgui::textbox::get_font(), m_text);
+	{
+		fgui::render.text(area.left + 5, area.top + (area.bottom / 2) - (typed_text_size.height / 2) - 1, fgui::color(style.text.at(0)), fgui::textbox::get_font(), to_write);
+	}
 
 	// if the textbox is ready to receive text
 	if (m_is_getting_key) {
 
 		// caret
-		std::string caret = m_text;
-		caret.erase(m_text_input_pos, caret.size());
+		std::string caret = to_write;
+
+		if (m_text_input_pos - number_errased <= 0)
+		{
+			number_errased = 0;
+			m_text_input_pos = 1;
+		}
+		if (m_text_input_pos - number_errased > caret.size())
+		{
+			m_text_input_pos = caret.size();
+			number_errased = 0;
+		}
+
+		caret.erase(m_text_input_pos - number_errased, caret.size());
 
 		// caret size
 		fgui::dimension caret_text_size = fgui::render.get_text_size(fgui::textbox::get_font(), caret);


### PR DESCRIPTION
textbox.cc keeps textwithin box

Container.cc prevents 2 textboxes being active at a time to type into. (probably a better way to do this especialy if element stores type definition in it. An enum to do this would be nice - this may mess up how multibox works, As I haven't looked at that.